### PR TITLE
Flags for webpack debug and production mode

### DIFF
--- a/lektor_webpack_support.py
+++ b/lektor_webpack_support.py
@@ -16,12 +16,30 @@ class WebpackSupportPlugin(Plugin):
     def is_enabled(self, build_flags):
         return bool(build_flags.get('webpack'))
 
-    def run_webpack(self, watch=False):
+    def is_debug(self, build_flags):
+        return bool(build_flags.get('debug'))
+
+    def is_production(self, build_flags):
+        return bool(build_flags.get('production'))
+
+    def get_mode(self, build_flags):
+        if self.is_debug(build_flags):
+            return 'd'
+        elif self.is_production(build_flags):
+            return 'p'
+
+    def run_webpack(self, watch=False, mode=None):
         webpack_root = os.path.join(self.env.root_path, 'webpack')
         args = [os.path.join(webpack_root, 'node_modules', '.bin', 'webpack')]
+        env = os.environ.copy()
         if watch:
             args.append('--watch')
-        return portable_popen(args, cwd=webpack_root)
+        if mode is 'd':
+            args.append('-d')
+        elif mode is 'p':
+            args.append('-p')
+            env['NODE_ENV'] = 'production'
+        return portable_popen(args, cwd=webpack_root, env=env)
 
     def npm_install(self):
         reporter.report_generic('Running npm install')
@@ -33,7 +51,7 @@ class WebpackSupportPlugin(Plugin):
             return
         self.npm_install()
         reporter.report_generic('Spawning webpack watcher')
-        self.webpack_process = self.run_webpack(watch=True)
+        self.webpack_process = self.run_webpack(watch=True, mode=self.get_mode(build_flags))
 
     def on_server_stop(self, **extra):
         if self.webpack_process is not None:
@@ -46,5 +64,5 @@ class WebpackSupportPlugin(Plugin):
             return
         self.npm_install()
         reporter.report_generic('Starting webpack build')
-        self.run_webpack().wait()
+        self.run_webpack(mode=self.get_mode(builder.build_flags)).wait()
         reporter.report_generic('Webpack build finished')


### PR DESCRIPTION
Resolves #3

* `-f debug` passes the `-d` (development) flag to webpack.
* `-f production` passes the `-p` (production) flag to webpack and sets the `NODE_ENV` variable to "production" when running the webpack subprocess.