### PR TITLE
Add support for running arbitrary npm scripts to generate assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,56 +56,74 @@ idea is to build the files from `webpack/scss` and `webpack/js` into
 installed for as long as someone else ran it before.
 
 ```javascript
-var webpack = require('webpack');
-var path = require('path');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
+const webpack = require('webpack');
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+const extractPlugin = new ExtractTextPlugin({ filename: 'styles.css' });
 
-var options = {
+const config = {
+
+  context: path.resolve(__dirname),
+
   entry: {
-    'app': './js/main.js',
-    'styles': './scss/main.scss'
+    app: './js/main.js',
+    styles: './scss/main.scss'
   },
+
   output: {
     path: path.dirname(__dirname) + '/assets/static/gen',
     filename: '[name].js'
   },
-  devtool: '#cheap-module-source-map',
-  resolve: {
-    modulesDirectories: ['node_modules'],
-    extensions: ['', '.js']
-  },
+
   module: {
-    loaders: [
+    rules: [
+
+      //babel-loader
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader'
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ['env']
+          }
+        }
       },
+
+      //sass-loader
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader')
+        use: extractPlugin.extract({
+          use: [
+      {
+              loader: 'css-loader',
+              options: {
+                sourceMap: true
+              }
       },
       {
-        test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
-      },
-      {
-        test: /\.woff2?$|\.ttf$|\.eot$|\.svg$|\.png|\.jpe?g\|\.gif$/,
-        loader: 'file'
+              loader: 'sass-loader',
+              options: {
+                sourceMap: true
       }
+            }
+          ],
+          fallback: 'style-loader'
+        })
+      }
+
     ]
   },
-  plugins: [
-    new ExtractTextPlugin('styles.css', {
-      allChunks: true
-    }),
-    new webpack.optimize.UglifyJsPlugin(),
-    new webpack.optimize.DedupePlugin()
-  ]
-};
 
-module.exports = options;
+  plugins: [
+    extractPlugin
+  ],
+
+  devtool: 'inline-source-map'
+}
+
+module.exports = config;
 ```
 
 ## Creating the App

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 This is a plugin for Lektor that adds support for webpack to projects.  When
 enabled it can build a webpack project from the `webpack/` folder into the
 asset folder automatically when the server (or build process) is run with
-the `-f webpack` flag.
+the `-f webpack` flag. 
+In addition. it can be configured to run arbitrary `npm` scripts to support
+arbitrary build tools, such as [Parcel](https://parceljs.org).
 
 ## Enabling the Plugin
 
@@ -16,9 +18,9 @@ sitting in your Lektor project directory:
 lektor plugins add lektor-webpack-support
 ```
 
-## Creating a Webpack Project
+## Example 1: Creating a Webpack Project
 
-Next you need to create a webpack project. Create a `webpack/` folder and
+First create a webpack project. Create a `webpack/` folder and
 inside that folder create `package.json` and a `webpack.config.js`
 
 ### `webpack/package.json`
@@ -96,17 +98,17 @@ const config = {
         test: /\.scss$/,
         use: extractPlugin.extract({
           use: [
-      {
+            {
               loader: 'css-loader',
               options: {
                 sourceMap: true
               }
-      },
-      {
+            },
+            {
               loader: 'sass-loader',
               options: {
                 sourceMap: true
-      }
+              }
             }
           ],
           fallback: 'style-loader'
@@ -126,12 +128,85 @@ const config = {
 module.exports = config;
 ```
 
-## Creating the App
+### Creating the App
 
 Now we can start building our app.  We configured at least two files
 in webpack: `js/main.js` and `scss/main.scss`.  Those are the entry
 points we need to have.  You can create them as empty files in
 `webpack/js/main.js` and `webpack/scss/main.scss`.
+
+## Example 2: Creating a [Parcel](https://parceljs.org/) Project
+
+To create a Parcel project, create a `parcel/` folder and inside that folder create the following files:
+
+### `configs/webpack-support.ini`
+
+This file instructs the plugin how to generate the assets. 
+
+* `name` will be used in the output instead of 'webpack',
+* `folder` should point to the project subforlder containing the parcel project, 
+* `watch_script` is the npm script used in `lektor server -f webpack`,
+* `build_script` is the npm script used in `lektor build -f webpack`.
+
+```ini
+name = Parcel
+folder = parcel
+watch_script = watch
+build_script = build
+```
+
+### `parcel/package.json`
+
+Similar to the webpack example above we need a `package.json` file. But in addition, we need to provide the npm scripts to use for `lektor build -f webpack` and `lektor watch -f webpack`.
+
+```json
+{
+  "name": "lektor-webpack",
+  "version": "1.0.0",
+  "scripts": {
+    "watch": "NODE_ENV=development parcel --out-dir=../assets/static/gen --out-file=main.js --public-url=./assets/ js/main.js",
+    "build": "NODE_ENV=production parcel build --out-dir=../assets/static/gen --out-file=main.js --public-url=./assets/ js/main.js"
+  },
+  "private": true
+}
+```
+
+Now we can `npm install` (or `yarn add`) the rest:
+
+```
+$ cd </path/to/your/lektor/project>/parcel
+$ npm install --save-dev parcel-bundler babel-preset-env node-sass
+```
+
+This will install Parcel, babel and sass. 
+
+### `parcel/babelr.rc`
+
+Next up is a simple Babel config file, using the recommened env preset.
+
+```json
+{
+  "presets": ["env"]
+}
+```
+
+### `parcel/main.scss`
+
+A simple SCSS file.
+
+```scss
+body {
+  border: 10px solid red;
+}
+```
+
+### `parcel/main.js`
+
+A simple Javascript file that imports the SCSS file so that Parcel will know to include it as well.
+
+```javascript
+import './main.scss';
+```
 
 ## Running the Server
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+gen/

--- a/examples/parcel-example/configs/webpack-support.ini
+++ b/examples/parcel-example/configs/webpack-support.ini
@@ -1,0 +1,4 @@
+name = Parcel
+folder = parcel
+watch_script = watch
+build_script = build

--- a/examples/parcel-example/content/about/contents.lr
+++ b/examples/parcel-example/content/about/contents.lr
@@ -1,0 +1,7 @@
+title: About this Website
+---
+body:
+
+This is a website that was made with the Lektor quickstart.
+
+And it does not contain a lot of information.

--- a/examples/parcel-example/content/contents.lr
+++ b/examples/parcel-example/content/contents.lr
@@ -1,0 +1,6 @@
+title: Welcome to parcel-example!
+---
+body:
+
+This is a basic demo website that shows how to use Lektor for a basic
+website with some pages.

--- a/examples/parcel-example/content/projects/contents.lr
+++ b/examples/parcel-example/content/projects/contents.lr
@@ -1,0 +1,9 @@
+title: Projects
+---
+body:
+
+This is a list of the projects:
+
+* Project 1
+* Project 2
+* Project 3

--- a/examples/parcel-example/models/page.ini
+++ b/examples/parcel-example/models/page.ini
@@ -1,0 +1,11 @@
+[model]
+name = Page
+label = {{ this.title }}
+
+[fields.title]
+label = Title
+type = string
+
+[fields.body]
+label = Body
+type = markdown

--- a/examples/parcel-example/parcel-example.lektorproject
+++ b/examples/parcel-example/parcel-example.lektorproject
@@ -1,0 +1,5 @@
+[project]
+name = parcel-example
+
+[packages]
+lektor-webpack-support = 0.3

--- a/examples/parcel-example/parcel/main.js
+++ b/examples/parcel-example/parcel/main.js
@@ -1,0 +1,1 @@
+import './main.scss';

--- a/examples/parcel-example/parcel/main.scss
+++ b/examples/parcel-example/parcel/main.scss
@@ -1,0 +1,42 @@
+body {
+    font-family: 'Verdana', sans-serif;
+    margin: 50px 25px;
+}
+
+a {
+    color: #2a99b6;
+}
+
+a:hover {
+    color: #33bbdf;
+}
+
+header, footer, div.page {
+    width: 760px;
+    margin: 0 auto;
+    background: #daeef3;
+    padding: 20px 30px;
+}
+
+header h1 {
+    color: #169bbd;
+    margin: 0;
+    font-weight: normal;
+    font-size: 42px;
+}
+
+header nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+header nav ul li {
+    display: inline;
+    margin: 0 8px 0 0;
+    padding: 0;
+}
+
+div.page {
+    background: #f1fbfe;
+}

--- a/examples/parcel-example/parcel/package.json
+++ b/examples/parcel-example/parcel/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lektor-webpack",
+  "version": "1.0.0",
+  "scripts": {
+    "watch": "NODE_ENV=development parcel --out-dir=../assets/static/gen --out-file=main.js --public-url=./assets/ main.js",
+    "build": "NODE_ENV=production parcel build --out-dir=../assets/static/gen --out-file=main.js --public-url=./assets/ main.js"
+  },
+  "private": true,
+  "devDependencies": {
+    "babel-preset-env": "^1.6.1",
+    "node-sass": "^4.7.2",
+    "parcel-bundler": "^1.6.2"
+  }
+}

--- a/examples/parcel-example/templates/layout.html
+++ b/examples/parcel-example/templates/layout.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="{{ '/static/gen/main.css'| url }}">
+<title>{% block title %}Welcome{% endblock %} — webpack-example</title>
+<body>
+  <header>
+    <h1>webpack-example</h1>
+    <nav>
+      <ul class="nav navbar-nav">
+        <li{% if this._path == '/' %} class="active"{% endif
+          %}><a href="{{ '/'|url }}">Welcome</a></li>
+        {% for href, title in [
+          ['/projects', 'Projects'],
+          ['/about', 'About']
+        ] %}
+          <li{% if this.is_child_of(href) %} class="active"{% endif
+            %}><a href="{{ href|url }}">{{ title }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+  </header>
+  <div class="page">
+    {% block body %}{% endblock %}
+  </div>
+  <footer>
+    A Footer.
+  </footer>
+  <script src="{{ '/static/gen/main.js' | url }}"></script>
+</body>

--- a/examples/parcel-example/templates/macros/pagination.html
+++ b/examples/parcel-example/templates/macros/pagination.html
@@ -1,0 +1,15 @@
+{% macro render_pagination(pagination) %}
+  <div class="pagination">
+    {% if pagination.has_prev %}
+      <a href="{{ pagination.prev|url }}">&laquo; Previous</a>
+    {% else %}
+      <span class="disabled">&laquo; Previous</span>
+    {% endif %}
+    | {{ pagination.page }} |
+    {% if pagination.has_next %}
+      <a href="{{ pagination.next|url }}">Next &raquo;</a>
+    {% else %}
+      <span class="disabled">Next &raquo;</span>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/examples/parcel-example/templates/page.html
+++ b/examples/parcel-example/templates/page.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block title %}{{ this.title }}{% endblock %}
+{% block body %}
+  <h2>{{ this.title }}</h2>
+  {{ this.body }}
+{% endblock %}

--- a/examples/webpack-example/content/about/contents.lr
+++ b/examples/webpack-example/content/about/contents.lr
@@ -1,0 +1,7 @@
+title: About this Website
+---
+body:
+
+This is a website that was made with the Lektor quickstart.
+
+And it does not contain a lot of information.

--- a/examples/webpack-example/content/contents.lr
+++ b/examples/webpack-example/content/contents.lr
@@ -1,0 +1,6 @@
+title: Welcome to webpack-example!
+---
+body:
+
+This is a basic demo website that shows how to use Lektor for a basic
+website with some pages.

--- a/examples/webpack-example/content/projects/contents.lr
+++ b/examples/webpack-example/content/projects/contents.lr
@@ -1,0 +1,9 @@
+title: Projects
+---
+body:
+
+This is a list of the projects:
+
+* Project 1
+* Project 2
+* Project 3

--- a/examples/webpack-example/models/page.ini
+++ b/examples/webpack-example/models/page.ini
@@ -1,0 +1,11 @@
+[model]
+name = Page
+label = {{ this.title }}
+
+[fields.title]
+label = Title
+type = string
+
+[fields.body]
+label = Body
+type = markdown

--- a/examples/webpack-example/templates/layout.html
+++ b/examples/webpack-example/templates/layout.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="{{ '/static/gen/styles.css'| url }}">
+<title>{% block title %}Welcome{% endblock %} — webpack-example</title>
+<body>
+  <header>
+    <h1>webpack-example</h1>
+    <nav>
+      <ul class="nav navbar-nav">
+        <li{% if this._path == '/' %} class="active"{% endif
+          %}><a href="{{ '/'|url }}">Welcome</a></li>
+        {% for href, title in [
+          ['/projects', 'Projects'],
+          ['/about', 'About']
+        ] %}
+          <li{% if this.is_child_of(href) %} class="active"{% endif
+            %}><a href="{{ href|url }}">{{ title }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+  </header>
+  <div class="page">
+    {% block body %}{% endblock %}
+  </div>
+  <footer>
+    A Footer.
+  </footer>
+  <script src="{{ '/static/gen/app.js' | url }}"></script>
+</body>

--- a/examples/webpack-example/templates/macros/pagination.html
+++ b/examples/webpack-example/templates/macros/pagination.html
@@ -1,0 +1,15 @@
+{% macro render_pagination(pagination) %}
+  <div class="pagination">
+    {% if pagination.has_prev %}
+      <a href="{{ pagination.prev|url }}">&laquo; Previous</a>
+    {% else %}
+      <span class="disabled">&laquo; Previous</span>
+    {% endif %}
+    | {{ pagination.page }} |
+    {% if pagination.has_next %}
+      <a href="{{ pagination.next|url }}">Next &raquo;</a>
+    {% else %}
+      <span class="disabled">Next &raquo;</span>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/examples/webpack-example/templates/page.html
+++ b/examples/webpack-example/templates/page.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block title %}{{ this.title }}{% endblock %}
+{% block body %}
+  <h2>{{ this.title }}</h2>
+  {{ this.body }}
+{% endblock %}

--- a/examples/webpack-example/webpack-example.lektorproject
+++ b/examples/webpack-example/webpack-example.lektorproject
@@ -1,0 +1,5 @@
+[project]
+name = webpack-example
+
+[packages]
+lektor-webpack-support = 0.3

--- a/examples/webpack-example/webpack/package.json
+++ b/examples/webpack-example/webpack/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "lektor-webpack",
+    "version": "1.0.0",
+    "private": true,
+    "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "css-loader": "^0.28.9",
+        "extract-text-webpack-plugin": "^3.0.2",
+        "file-loader": "^1.1.8",
+        "node-sass": "^4.7.2",
+        "sass-loader": "^6.0.6",
+        "style-loader": "^0.20.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.11.0"
+    },
+    "dependencies": {
+        "babel-preset-env": "^1.6.1"
+    }
+}

--- a/examples/webpack-example/webpack/scss/main.scss
+++ b/examples/webpack-example/webpack/scss/main.scss
@@ -1,0 +1,42 @@
+body {
+    font-family: 'Verdana', sans-serif;
+    margin: 50px 25px;
+}
+
+a {
+    color: #2a99b6;
+}
+
+a:hover {
+    color: #33bbdf;
+}
+
+header, footer, div.page {
+    width: 760px;
+    margin: 0 auto;
+    background: #daeef3;
+    padding: 20px 30px;
+}
+
+header h1 {
+    color: #169bbd;
+    margin: 0;
+    font-weight: normal;
+    font-size: 42px;
+}
+
+header nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+header nav ul li {
+    display: inline;
+    margin: 0 8px 0 0;
+    padding: 0;
+}
+
+div.page {
+    background: #f1fbfe;
+}

--- a/examples/webpack-example/webpack/webpack.config.js
+++ b/examples/webpack-example/webpack/webpack.config.js
@@ -1,0 +1,69 @@
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const webpack = require('webpack');
+
+const extractPlugin = new ExtractTextPlugin({ filename: 'styles.css' });
+
+const config = {
+
+  context: path.resolve(__dirname),
+
+  entry: {
+    app: './js/main.js',
+    styles: './scss/main.scss'
+  },
+
+  output: {
+    path: path.dirname(__dirname) + '/assets/static/gen',
+    filename: '[name].js'
+  },
+
+  module: {
+    rules: [
+
+      //babel-loader
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ['env']
+          }
+        }
+      },
+
+      //sass-loader
+      {
+        test: /\.scss$/,
+        use: extractPlugin.extract({
+          use: [
+            {
+              loader: 'css-loader',
+              options: {
+                sourceMap: true
+              }
+            },
+            {
+              loader: 'sass-loader',
+              options: {
+                sourceMap: true
+              }
+            }
+          ],
+          fallback: 'style-loader'
+        })
+      }
+
+    ]
+  },
+
+  plugins: [
+    extractPlugin
+  ],
+
+  devtool: 'inline-source-map'
+ 
+}
+
+module.exports = config;

--- a/tests/demo-scripts-project/Website.lektorproject
+++ b/tests/demo-scripts-project/Website.lektorproject
@@ -1,0 +1,2 @@
+[project]
+name = Demo Project

--- a/tests/demo-scripts-project/configs/webpack-support.ini
+++ b/tests/demo-scripts-project/configs/webpack-support.ini
@@ -1,0 +1,4 @@
+name = Parcel
+folder = parcel
+build_script = build
+watch_script = watch

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -11,47 +11,47 @@ def test_enabled_with_webpack_flag(plugin):
     assert plugin.is_enabled(extra_flags)
 
 
-def test_basic(plugin, builder, env, mocker):
+def test_basic(expected, plugin, builder, env, mocker):
     mock_popen = mocker.patch("lektor_webpack_support.portable_popen")
     plugin.on_before_build_all(builder)
     env_path = py.path.local(env.root_path)
     mock_popen.assert_any_call(
         ["npm", "install"],
-        cwd=env_path / 'webpack'
+        cwd=env_path / expected.root_path
     )
     mock_popen.assert_any_call(
-        [env_path / 'webpack' / 'node_modules' / '.bin' / 'webpack'],
-        cwd=env_path / 'webpack'
+        expected.build_command,
+        cwd=env_path / expected.root_path
     )
     assert plugin.webpack_process is None
 
 
-def test_watcher(plugin, env, mocker):
+def test_watcher(expected, plugin, env, mocker):
     mock_popen = mocker.patch("lektor_webpack_support.portable_popen")
     plugin.on_server_spawn(extra_flags={"webpack": True})
     env_path = py.path.local(env.root_path)
     mock_popen.assert_any_call(
         ["npm", "install"],
-        cwd=env_path / 'webpack'
+        cwd=env_path / expected.root_path
     )
     mock_popen.assert_any_call(
-        [env_path / 'webpack' / 'node_modules' / '.bin' / 'webpack', '--watch'],
-        cwd=env_path / 'webpack'
+        expected.watch_command,
+        cwd=env_path / expected.root_path
     )
     assert plugin.webpack_process is mock_popen.return_value
 
 
-def test_watcher_build_flags(plugin, env, mocker):
+def test_watcher_build_flags(expected, plugin, env, mocker):
     mock_popen = mocker.patch("lektor_webpack_support.portable_popen")
     plugin.on_server_spawn(build_flags={"webpack": True})
     env_path = py.path.local(env.root_path)
     mock_popen.assert_any_call(
         ["npm", "install"],
-        cwd=env_path / 'webpack'
+        cwd=env_path / expected.root_path
     )
     mock_popen.assert_any_call(
-        [env_path / 'webpack' / 'node_modules' / '.bin' / 'webpack', '--watch'],
-        cwd=env_path / 'webpack'
+        expected.watch_command,
+        cwd=env_path / expected.root_path
     )
     assert plugin.webpack_process is mock_popen.return_value
 
@@ -68,7 +68,7 @@ def test_server_stop(plugin, mocker):
     plugin.webpack_process.kill.assert_called_with()
 
 
-def test_yarn_support(plugin, env, mocker):
+def test_yarn_support(expected, plugin, env, mocker):
     mock_popen = mocker.patch('lektor_webpack_support.portable_popen')
 
     mock_path_exists = mocker.patch('os.path.exists')
@@ -86,5 +86,5 @@ def test_yarn_support(plugin, env, mocker):
     mock_locate_executable.assert_any_call('yarn')
     mock_popen.assert_any_call(
         ['yarn', 'install'],
-        cwd=env_path / 'webpack'
+        cwd=env_path / expected.root_path
     )


### PR DESCRIPTION
Hi,

Currently this plugin is limited to running webpack to generate assets . I have modified the plugin to support, in addition to webpack, generating assets by running arbitrary scripts as specified in the package.json.

The new behavior can be activated by adding a `configs/webpack-support.ini`. Please see the new README for details.

While this change might warrant its own plugin, such a plugin would mostly be a duplciated of this plugin. The changes to support arbitrary scripts are small and will save the need to maintain two mostly identical plugins.

In addition, this set of commits contains (as separate commits):

1. Updated README.md with a working `webpack.config.js` for webpack 3. This can be merged even if the arbitrary npm scripts support is not accepted.

2. Updated tests for the new feature.

3. Working webpack and Parcel examples. The webpack example can be merged even if the arbitrary npm scripts support is not accepted.

Thanks,
Baruch