### PR TITLE
Upgrade to webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var options = {
     ]
   },
   plugins: [
-    new ExtractTextPlugin({filename: 'styles.css'}
+    new ExtractTextPlugin({filename: 'styles.css'})
   ]
 };
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Now we can `npm install` (or `yarn add`) the rest:
 
 ```
 $ cd </path/to/your/lektor/project>/webpack
-$ npm install --save-dev webpack babel-core node-sass babel-loader sass-loader css-loader url-loader style-loader file-loader extract-text-webpack-plugin
+$ npm install --save-dev webpack-cli @babel/core sass babel-loader sass-loader css-loader url-loader file-loader mini-css-extract-plugin
 ```
 
 This will install webpack itself together with babel and sass as well as
@@ -56,9 +56,8 @@ idea is to build the files from `webpack/scss` and `webpack/js` into
 installed for as long as someone else ran it before.
 
 ```javascript
-var webpack = require('webpack');
 var path = require('path');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 
 var options = {
@@ -70,38 +69,35 @@ var options = {
     path: path.dirname(__dirname) + '/assets/static/gen',
     filename: '[name].js'
   },
-  devtool: '#cheap-module-source-map',
+  devtool: 'cheap-module-source-map',
+  mode: 'production',
   resolve: {
-    modulesDirectories: ['node_modules'],
+    modules: ['node_modules'],
     extensions: ['', '.js']
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader'
+        use: ['babel-loader'],
       },
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader')
+        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader']
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
+        use: [MiniCssExtractPlugin.loader, 'css-loader']
       },
       {
         test: /\.woff2?$|\.ttf$|\.eot$|\.svg$|\.png|\.jpe?g\|\.gif$/,
-        loader: 'file'
+        use: ['file']
       }
     ]
   },
   plugins: [
-    new ExtractTextPlugin('styles.css', {
-      allChunks: true
-    }),
-    new webpack.optimize.UglifyJsPlugin(),
-    new webpack.optimize.DedupePlugin()
+    new ExtractTextPlugin({filename: 'styles.css'}
   ]
 };
 


### PR DESCRIPTION
This is based on my own webpack config which has minor changes.
Required changes:

Added npm dependencies:

  - webpack-cli

Removed npm dependencies:

  - style-loader: Not compatible with the new css extractor

Changed npm dependencies:

  - babel-core -> @babel/core
  - node-sass -> sass  # node-sass is deprecated
  - extract-text-webpack-plugin -> mini-css-extract-plugin

In the webpack config, I was able to remove the require('webpack') line.
The modules pulled from webpack are now included by default.
The valid parameters for devtool changed.
It is now a requirement to state, if one is running webpack in
production mode or not.
The module syntax has been changed.
I updated the plugins in the end of the file. The removed plugins aren't
required any more.

I will need to test the changes with the Lektor plugin.
js code worked for me, I have to validate that css still works.